### PR TITLE
Add typed welcome screen and auth routes

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,7 +19,8 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
+      <Stack initialRouteName="welcome">
+        <Stack.Screen name="welcome" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function LoginScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Login Screen</ThemedText>
+    </ThemedView>
+  );
+}

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function RegisterScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Register Screen</ThemedText>
+    </ThemedView>
+  );
+}

--- a/app/screens/WelcomeScreen.tsx
+++ b/app/screens/WelcomeScreen.tsx
@@ -1,0 +1,109 @@
+import { Link } from 'expo-router';
+import { Image } from 'expo-image';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/Colors';
+import React from 'react';
+import { StyleSheet, View, ScrollView } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+const slides = [
+  'Find a caring travel companion for your journey.',
+  'Secure and private matching system.',
+  'Peace of mind for you and your family.',
+];
+
+export default function WelcomeScreen() {
+  const colorScheme = useColorScheme();
+  const tint = Colors[colorScheme ?? 'light'].tint;
+
+  return (
+    <ThemedView style={styles.container}>
+      <Image
+        source={require('@/assets/images/icon.png')}
+        style={styles.logo}
+        accessibilityLabel="App logo"
+      />
+      <ThemedText type="title" style={styles.title}>
+        Bon Voyage Companion
+      </ThemedText>
+      <ThemedText type="subtitle" style={styles.tagline}>
+        Travel Together, Travel Safer.
+      </ThemedText>
+      <ScrollView
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.carousel}
+      >
+        {slides.map((text) => (
+          <ThemedView key={text} style={styles.slide}>
+            <ThemedText style={styles.slideText}>{text}</ThemedText>
+          </ThemedView>
+        ))}
+      </ScrollView>
+      <View style={styles.buttonRow}>
+        <Link
+          href="/login"
+          style={[styles.button, { backgroundColor: tint }]}
+          asChild
+        >
+          <ThemedText style={styles.buttonText}>Login</ThemedText>
+        </Link>
+        <Link
+          href="/register"
+          style={[styles.button, { backgroundColor: tint }]}
+          asChild
+        >
+          <ThemedText style={styles.buttonText}>Register</ThemedText>
+        </Link>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+    gap: 16,
+  },
+  logo: {
+    width: 120,
+    height: 120,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  tagline: {
+    textAlign: 'center',
+  },
+  carousel: {
+    paddingVertical: 16,
+  },
+  slide: {
+    width: 260,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 10,
+  },
+  slideText: {
+    textAlign: 'center',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 16,
+    marginTop: 24,
+  },
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 6,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/app/welcome.tsx
+++ b/app/welcome.tsx
@@ -1,0 +1,1 @@
+export { default } from './screens/WelcomeScreen';


### PR DESCRIPTION
## Summary
- create WelcomeScreen component with app branding and calls to action
- add login and register placeholder routes
- include a route file to expose WelcomeScreen at `/welcome`
- set `/welcome` as initial route in the app stack

## Testing
- `npx tsc --noEmit` *(fails: Cannot find global value 'Promise' and missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6877c24240d8832da679183e6f9373d3